### PR TITLE
Implement version marker "forsydeVersion"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,3 +43,5 @@ script:
 # `cabal install --force-reinstalls dist/*-*.tar.gz`
  - SRC_TGZ=$(cabal info . | awk '{print $2;exit}').tar.gz &&
    (cd dist && cabal install --force-reinstalls "$SRC_TGZ")
+# check the output of the version field:
+ - echo -e "import ForSyDe.Deep\nforsydeVersion" | ghci

--- a/ForSyDe-Deep.cabal
+++ b/ForSyDe-Deep.cabal
@@ -89,6 +89,7 @@ Library
                    Data.Typeable.FSDTypeRepLib,
                    Data.Traversable.GenericZipWith,
                    ForSyDe.Deep.Config,
+                   ForSyDe.Deep.Version,
                    ForSyDe.Deep.ForSyDeErr,
                    ForSyDe.Deep.Netlist,
                    ForSyDe.Deep.Netlist.Traverse,

--- a/src/ForSyDe/Deep.hs
+++ b/src/ForSyDe/Deep.hs
@@ -23,7 +23,8 @@ module ForSyDe.Deep
  module ForSyDe.Deep.Bit,
  module ForSyDe.Deep.AbsentExt,
  module ForSyDe.Deep.DFT,
- module ForSyDe.Deep.FIR) where
+ module ForSyDe.Deep.FIR,
+ forsydeVersion) where
 
 import ForSyDe.Deep.Ids
 import ForSyDe.Deep.Signal (Signal)
@@ -34,3 +35,4 @@ import ForSyDe.Deep.Backend
 import ForSyDe.Deep.AbsentExt
 import ForSyDe.Deep.DFT
 import ForSyDe.Deep.FIR
+import ForSyDe.Deep.Config (forsydeVersion)

--- a/src/ForSyDe/Deep/Config.hs
+++ b/src/ForSyDe/Deep/Config.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE TemplateHaskell, CPP #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  ForSyDe.Deep.Config
@@ -12,9 +12,12 @@
 -- Configuration values of ForSyDe
 --
 -----------------------------------------------------------------------------
-module ForSyDe.Deep.Config (maxTupleSize, module Paths_ForSyDe_Deep) where
+module ForSyDe.Deep.Config (forsydeVersion,
+                            maxTupleSize,
+                            module Paths_ForSyDe_Deep) where
 
 import Paths_ForSyDe_Deep
+import ForSyDe.Deep.Version (gitVersion)
 
 #ifdef DEVELOPER
 maxTupleSize :: Int
@@ -23,3 +26,4 @@ maxTupleSize = 8
 import GHC.Exts (maxTupleSize)
 #endif
 
+forsydeVersion = $(gitVersion)

--- a/src/ForSyDe/Deep/Config.hs
+++ b/src/ForSyDe/Deep/Config.hs
@@ -17,7 +17,7 @@ module ForSyDe.Deep.Config (forsydeVersion,
                             module Paths_ForSyDe_Deep) where
 
 import Paths_ForSyDe_Deep
-import ForSyDe.Deep.Version (gitVersion)
+import ForSyDe.Deep.Version (getVersion)
 
 #ifdef DEVELOPER
 maxTupleSize :: Int
@@ -26,4 +26,4 @@ maxTupleSize = 8
 import GHC.Exts (maxTupleSize)
 #endif
 
-forsydeVersion = $(gitVersion)
+forsydeVersion = $(getVersion)

--- a/src/ForSyDe/Deep/Version.hs
+++ b/src/ForSyDe/Deep/Version.hs
@@ -12,14 +12,24 @@
 --
 -----------------------------------------------------------------------------
 
-module ForSyDe.Deep.Version (gitVersion) where
+module ForSyDe.Deep.Version (getVersion) where
+
+import Paths_ForSyDe_Deep (version)
+import Data.Version (showVersion)
 
 import Language.Haskell.TH (runIO)
 import Language.Haskell.TH.Syntax
 import System.Process (readProcess)
+import Control.Exception (catch)
+import System.IO.Error (IOError)
 
-gitVersion :: Q Exp
-gitVersion = do
-        vstr <- runIO $ readProcess "git" ["describe", "--tags", "--dirty"] ""
+getVersion :: Q Exp
+getVersion = do
+        vstr <- runIO $ catch version_git version_cabal
         return (LitE $ StringL $ init vstr)
 
+  where
+    version_git :: IO String
+    version_git = readProcess "git" ["describe", "--tags", "--dirty"] ""
+    version_cabal :: IOError -> IO String
+    version_cabal _ = return $ showVersion version

--- a/src/ForSyDe/Deep/Version.hs
+++ b/src/ForSyDe/Deep/Version.hs
@@ -1,0 +1,25 @@
+-----------------------------------------------------------------------------
+-- |
+-- Module      :  ForSyDe.Deep.Version
+-- Copyright   :  (c) ES Group, KTH/ICT/ES 2016
+-- License     :  BSD-style (see the file LICENSE)
+-- 
+-- Maintainer  :  forsyde-dev@ict.kth.se
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Version information for the current build
+--
+-----------------------------------------------------------------------------
+
+module ForSyDe.Deep.Version (gitVersion) where
+
+import Language.Haskell.TH (runIO)
+import Language.Haskell.TH.Syntax
+import System.Process (readProcess)
+
+gitVersion :: Q Exp
+gitVersion = do
+        vstr <- runIO $ readProcess "git" ["describe", "--tags", "--dirty"] ""
+        return (LitE $ StringL $ init vstr)
+


### PR DESCRIPTION
Using `git describe` from within TH to store forsydeVersion at compile
time.

Fixes #26 Print Version Information
https://github.com/forsyde/forsyde-deep/issues/26
